### PR TITLE
simplify requirements in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,17 +118,6 @@ environment variable `PYLLOCK_ENV` to `"main"` or `"prod"`. If unset, Pyllock wi
 Pyllock only works in Linux and Unix environments. It's designed for use with Bash, and hasn't been
 tested with other shells. It also expects the following programs are available:
 
-- Usual tools:
-  - `awk`
-  - `column`
-  - `curl`
-  - `echo`
-  - `find`
-  - `mkdir`
-  - `mv`
-  - `rm`
-  - `sed`
-  - `touch`
 - GNU `make`
     - Tested with GNU Make 4.3.
     - Doesn't work with "standard" `make`. Pyllock relies on features of GNU Make.
@@ -206,7 +195,6 @@ Also, huge thanks to [Hynek Schlawack][blog] for giving me the idea to use `pypr
 `Makefile` to begin with.
 
 [blog]: https://hynek.me/til/pip-tools-and-pyproject-toml/
-
 
 ## Acknowledgement
 


### PR DESCRIPTION
No need to list out individual parts of core utils.