### PR TITLE
pin minimum pip-tools version for pip 25.3 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #################
 # Pyllock Makefile
-# v0.9.2
+# v0.9.3
 #
 # For more details, see https://github.com/Zoidmania/pyllock.
 #
@@ -80,7 +80,8 @@ endif
 # Pin the pip-tools version range so this Makefile can predict its behavior. Pip follows version
 # specifiers outlined in PEP440, even inline on the CLI. Note that, if a range is specified like
 # this, it must be surrounded with quotes.
-PYLLOCK_PIPTOOLS_VERSION ?= >=7.5.1,<8
+# Nota bene: pip-tools 7.5.2 is the minimum version that supports pip 25.3.
+PYLLOCK_PIPTOOLS_VERSION ?= >=7.5.2,<8
 
 # Respect https://no-color.org/.
 NO_COLOR ?= 0

--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@
 [![Pronunciation](https://img.shields.io/badge/pronounciation-like_%22pilluck%22-blue)](#)
 [![Footgun?](https://img.shields.io/badge/jury's%20out-red?style=flat&label=footgun%3F)](https://news.ycombinator.com/item?id=17393292)
 
-Pyllock is a simple, probably stupid Python project manager. It's a Makefile being used as a command
-runner.
+Pyllock is a simple, probably stupid Python project manager. It's a Makefile command runner
+wrapping `pip-tools`.
 
 On Linux or Unix/Mac systems, I like to use Makefiles, `pyproject.toml`, and
 [`pip-tools`][pip-tools] to manage my Python projects these days. Pyllock will:


### PR DESCRIPTION
Closes #46.